### PR TITLE
Include make commands

### DIFF
--- a/modern.configuration.json
+++ b/modern.configuration.json
@@ -5,6 +5,13 @@
 	},
 	// symbols used as brackets
 	"brackets": [
-		["(", ")"]
-	]
+		[
+			"(",
+			")"
+		]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "^\\s*((module|contains|function|subroutine|begin|else|elsif|do|for|case|select case|type)|(if\\b.*\\bthen))\\b",
+		"decreaseIndentPattern": "^\\s*(contains|end|else|elseif|endif|case)\\b"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,18 @@
                 "path": "./syntaxes/fortran.tmLanguage"
             }
         ],
+        "commands": [
+            {
+                "command": "fortran.make_all",
+                "title": "Make all",
+                "category": "Fortran"
+            },
+            {
+                "command": "fortran.make_clean",
+                "title": "Make clean",
+                "category": "Fortran"
+            }
+        ],
         "snippets": [
             {
                 "language": "fortran-modern",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,23 +2,16 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode'; 
 
+
+make_all() {
+	if (!vscode.window.activeTextEditor || !LANGUAGE_IS_FORTRAN) {
+	    return
+	}
+	RUN_MAKE_COMMAND
+}
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "fortran" is now active!'); 
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	var disposable = vscode.commands.registerCommand('extension.sayHello', () => {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World!');
-	});
-	
-	context.subscriptions.push(disposable);
+	vscode.commands.registerCommand('fortran.make_all', () => make_all())
+	GET_OUTPUT_TO_SOME_CONSOLE
 }


### PR DESCRIPTION
Hi.

I think it would be great to have the fortran extension providing some basic features like "make" out of the box (i.e. without installing third party all-purpose code runners).

Unfortunately, I have no real knowledge on how to program VSCODE, and don't know typescript. So I propose here a NON WORKING pull request, as a starting point for anyone willing to do the actual work, should you agree with the idea.

I looked into the code of "latex-workshop", which provides a "build" command and did some copy-paste : 
- package.json to declare the featured command (missing a default keybinding, like alt shift b, for build)
- extension.ts to declare the functions at load time, and the actual functions.

I left in CAPITALS the parts that I don't know how to code.
If you are willing to implement this, it would be great. Of course, I'd be happy to help further if I can :)